### PR TITLE
Fixed LinkedIn Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <h3 align="left">Connect with me:</h3>
 <p align="left">
-<a href="https://linkedin.com/in/https://www.linkedin.com/in/aabha-lokhande-559334259/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="https://www.linkedin.com/in/aabha-lokhande-559334259/" height="30" width="40" /></a>
+<a href="https://www.linkedin.com/in/aabha-lokhande-559334259/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="https://www.linkedin.com/in/aabha-lokhande-559334259/" height="30" width="40" /></a>
 </p>
 
 <h3 align="left">Languages and Tools:</h3>


### PR DESCRIPTION
Earlier the Link on click opened this tab :-
![image](https://github.com/gitwithaabha/gitwithaabha/assets/85815858/02bf27d5-9f49-4bf8-b25c-5b18b4a4ce3e)

But now this has been fixed :-
![image](https://github.com/gitwithaabha/gitwithaabha/assets/85815858/6f83d051-abef-47bc-b9e9-43a643b031c0)

